### PR TITLE
feat(blog): post testeabilidad vs observabilidad + mejoras Mermaid y redacción

### DIFF
--- a/src/content/blog/03-postgresql-como-cola-de-mensajeria.md
+++ b/src/content/blog/03-postgresql-como-cola-de-mensajeria.md
@@ -1,5 +1,5 @@
 ---
-title: "PostgreSQL como cola de mensajería? Depende."
+title: "¿PostgreSQL como cola de mensajería? Depende."
 description: "Reflexiones sobre cuándo usar PostgreSQL como event bus, cómo implementarlo con dos tablas y cómo se relaciona con las transacciones en sistemas con arquitectura orientada a eventos."
 pubDate: 2025-02-03
 tags: ["Event-Driven Architecture", "PostgreSQL", "DDD", "Clean Architecture", "SOLID", "Infraestructura"]
@@ -28,7 +28,7 @@ tags: ["Event-Driven Architecture", "PostgreSQL", "DDD", "Clean Architecture", "
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Volviendo a la pregunta del principio: de vuelta, <strong>depende</strong>. Un bus en memoria podría solventar todos los problemas de mantenibilidad y testeabilidad, y en caso de ser un sistema sencillo donde podamos permitirnos sincronía, es una buena solución.
+  Volviendo a la pregunta del principio: una vez más, <strong>depende</strong>. Un bus en memoria podría resolver todos los problemas de mantenibilidad y testeabilidad y, en el caso de un sistema sencillo en el que podamos permitirnos sincronía, es una buena solución.
 </p>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
@@ -64,17 +64,25 @@ tags: ["Event-Driven Architecture", "PostgreSQL", "DDD", "Clean Architecture", "
 </p>
 
 ```mermaid
-flowchart TD
-    UC[Use Case] -->|publica| EB[Event Bus]
-    EB -->|inserta| EV[(domain_events)]
-    EV -->|referencia| SR[(event_subscribers)]
-    W[Worker] -->|poll + SKIP LOCKED| EV
-    W -->|ejecuta| S1[Subscriber A]
-    W -->|ejecuta| S2[Subscriber B]
+flowchart TB
+    UC[Use Case]
+    EB[Event Bus]
+    EV[(domain_events)]
+    SR[(event_subscribers)]
+    W[Worker]
+    S1[Subscriber A]
+    S2[Subscriber B]
+    DL[(dead_letter)]
+
+    UC -->|publica| EB
+    EB -->|inserta| EV
+    EV -.->|referencia| SR
+    EV -->|poll + SKIP LOCKED| W
+    W --> S1
+    W --> S2
     S1 -->|marca procesado| EV
     S2 -->|marca procesado| EV
-    EV -->|fallo → retry| W
-    EV -->|max retries| DL[(dead_letter)]
+    EV -->|max retries| DL
 
     style EV fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff
     style SR fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff

--- a/src/content/blog/04-lo-que-la-ia-no-te-hace.md
+++ b/src/content/blog/04-lo-que-la-ia-no-te-hace.md
@@ -26,11 +26,11 @@ tags: ["IA", "Patrones de Diseño", "Criteria", "Clean Architecture", "DDD", "In
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Lo que la IA no hace es <strong>diseñar a largo plazo</strong>. Puede que te sirva para apagar un fuego, pero no te da para acabar con el incendio. Por lo menos si no la guiás en soluciones completas. Dándole tus gafas. Tus ideas. Tu conocimiento.
+  Lo que la IA no hace es <strong>diseñar a largo plazo</strong>. Puede que te sirva para apagar un fuego, pero no basta para acabar con el incendio. Al menos, si no la guías hacia soluciones completas. Le das tus gafas. Tus ideas. Tu conocimiento.
 </p>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
-  Si sos ingeniero de software, desarrollador o apasionado por la programación: <strong>aprende patrones de diseño. Aprende las bases.</strong> Y después, propúlsate usando IA. No hay ningún problema en eso.
+  Si eres ingeniero de software, desarrollador o alguien apasionado por la programación: <strong>aprende patrones de diseño. Aprende las bases.</strong> Y después, apóyate en la IA. No hay ningún problema en eso.
 </p>
 
 <br />
@@ -39,11 +39,11 @@ tags: ["IA", "Patrones de Diseño", "Criteria", "Clean Architecture", "DDD", "In
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Como ejemplo de lo que significa diseñar con intención, os dejo una solución a un problema bastante común en los sistemas: la capacidad de <strong>filtrar y paginar en una API de manera elegante y sostenible</strong>, sin que el repositorio crezca hasta el infinito.
+  Como ejemplo de lo que significa diseñar con intención, te dejo una solución a un problema bastante común en los sistemas: la capacidad de <strong>filtrar y paginar en una API de manera elegante y sostenible</strong>, sin que el repositorio crezca hasta el infinito.
 </p>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
-  El <strong>patrón Criteria</strong> resuelve exactamente eso. En vez de tener un método por cada combinación posible de filtros en el repositorio, encapsulás los criterios de búsqueda en un objeto que el repositorio sabe interpretar. El repositorio no crece. La lógica de filtrado vive en el dominio. Y podés componer criterios con libertad.
+  El <strong>patrón Criteria</strong> resuelve exactamente eso. En vez de tener un método por cada combinación posible de filtros en el repositorio, encapsulas los criterios de búsqueda en un objeto que el repositorio sabe interpretar. El repositorio no crece. La lógica de filtrado vive en el dominio. Y puedes componer criterios con libertad.
 </p>
 
 <div style="margin-top:1.5rem; border-left: 3px solid oklch(67.3% 0.182 276.935); padding-left:1rem;">
@@ -65,7 +65,7 @@ tags: ["IA", "Patrones de Diseño", "Criteria", "Clean Architecture", "DDD", "In
 </p>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
-  Este es exactamente el tipo de solución que la IA no te va a proponer sola. Necesita que vos llegues con el patrón en la cabeza, con el problema entendido, y la uses como acelerador. No como arquitecto.
+  Este es exactamente el tipo de solución que la IA no te va a proponer sola. Necesita que tú llegues con el patrón en la cabeza, con el problema entendido, y que la uses como acelerador. No como arquitecto.
 </p>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />

--- a/src/content/blog/05-criteria-filtros-dinamicos-paginacion-ddd.md
+++ b/src/content/blog/05-criteria-filtros-dinamicos-paginacion-ddd.md
@@ -6,7 +6,7 @@ tags: ["Criteria", "Specification Pattern", "DDD", "Clean Architecture", "TypeSc
 ---
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Cuando trabajas en aplicaciones reales, hay un momento inevitable: necesitás hacer búsquedas complejas.
+  Cuando trabajas en aplicaciones reales, hay un momento inevitable: necesitas hacer búsquedas complejas.
 </p>
 
 <blockquote style="border-left:3px solid oklch(67.3% 0.182 276.935); padding-left:1rem; margin:1.5rem 0; color:#94A3B8; font-style:italic;">
@@ -23,7 +23,7 @@ tags: ["Criteria", "Specification Pattern", "DDD", "Clean Architecture", "TypeSc
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  En cuanto empezás a añadir filtros dinámicos en tus repositorios:
+  En cuanto empiezas a añadir filtros dinámicos en tus repositorios:
 </p>
 
 <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:1rem;">
@@ -54,7 +54,7 @@ tags: ["Criteria", "Specification Pattern", "DDD", "Clean Architecture", "TypeSc
 
 <h3 style="color:oklch(67.3% 0.182 276.935); font-weight:600; margin-top:1.5rem;">🔗 Composición dinámica</h3>
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Podés combinar filtros sin modificar el repositorio:
+  Puedes combinar filtros sin modificar el repositorio:
 </p>
 
 ```ts
@@ -71,8 +71,9 @@ repository.match(criteria)
 ```
 
 ```mermaid
-flowchart LR
+flowchart TB
     subgraph Dominio
+        direction TB
         F1[Filter: role=admin]
         F2[Filter: status=active]
         O[Order: name ASC]
@@ -85,13 +86,15 @@ flowchart LR
     end
 
     subgraph Infraestructura
+        direction TB
         R[Repository.match]
         QB[QueryBuilder]
         DB[(PostgreSQL)]
-        C --> R
         R --> QB
         QB --> DB
     end
+
+    C --> R
 
     style C fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff
     style R fill:#0f172a,stroke:#818cf8,color:#e0e7ff
@@ -177,7 +180,7 @@ interface ContextRepository {
 </p>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
-  Dejás de escribir queries específicas para cada caso y empezás a construir un sistema flexible que evoluciona con vos. Y lo mejor: una vez lo implementás bien, no querés volver atrás.
+  Dejas de escribir queries específicas para cada caso y empiezas a construir un sistema flexible que evoluciona contigo. Y lo mejor: una vez lo implementas bien, no quieres volver atrás.
 </p>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />

--- a/src/content/blog/06-object-mother-datos-de-test.md
+++ b/src/content/blog/06-object-mother-datos-de-test.md
@@ -10,7 +10,7 @@ tags: ["Testing", "Object Mother", "TDD", "Code Finances", "TypeScript", "Buenas
 </p>
 
 <blockquote style="border-left:3px solid oklch(67.3% 0.182 276.935); padding-left:1rem; margin:1.5rem 0; color:#94A3B8; font-style:italic;">
-  "Para testear bien, primero necesitás datos válidos, coherentes y fáciles de generar."
+  "Para testear bien, primero necesitas datos válidos, coherentes y fáciles de generar."
 </blockquote>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
@@ -32,14 +32,14 @@ tags: ["Testing", "Object Mother", "TDD", "Code Finances", "TypeScript", "Buenas
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Cuando no tenés una estrategia clara para generar datos de test:
+  Cuando no tienes una estrategia clara para generar datos de test:
 </p>
 
 <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:0.75rem;">
-  <li>🧩 Repetís la creación de objetos en cada test</li>
+  <li>🧩 Repites la creación de objetos en cada test</li>
   <li>😵 Los tests se llenan de ruido (datos irrelevantes)</li>
   <li>🔧 Cambiar un campo rompe múltiples tests</li>
-  <li>🧠 Perdés foco en lo importante: el comportamiento</li>
+  <li>🧠 Pierdes el foco en lo importante: el comportamiento</li>
 </ul>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
@@ -137,10 +137,10 @@ const result = await revenueCreator.execute(request)
 <br />
 
 <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem;">
-  <li>Mantené los Object Mothers simples</li>
-  <li>Evitá lógica compleja o decisiones internas</li>
-  <li>Generá datos realistas, pero controlados</li>
-  <li>Si necesitás variaciones, permitir overrides sencillos</li>
+  <li>Mantén los Object Mothers simples</li>
+  <li>Evita lógica compleja o decisiones internas</li>
+  <li>Genera datos realistas, pero controlados</li>
+  <li>Si necesitas variaciones, permite <em>overrides</em> sencillos</li>
 </ul>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
@@ -160,7 +160,7 @@ const result = await revenueCreator.execute(request)
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Dependiendo del contexto, podés combinar o usar alternativas:
+  Dependiendo del contexto, puedes combinarlo con otras alternativas o utilizar enfoques distintos:
 </p>
 
 <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:0.75rem;">

--- a/src/content/blog/07-value-objects-guardianes-del-dominio.md
+++ b/src/content/blog/07-value-objects-guardianes-del-dominio.md
@@ -10,7 +10,7 @@ tags: ["Value Objects", "DDD", "SOLID", "Code Finances", "TypeScript", "Diseño 
 </p>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
-  Si estás trabajando con DDD o simplemente querés escribir código más robusto, esto te interesa.
+  Si estás trabajando con DDD o simplemente quieres escribir código más robusto, esto te interesa.
 </p>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
@@ -143,7 +143,7 @@ class LiquidityCategoryPercentage {
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Cuando necesitás modificar el valor, no mutás el objeto original. Creás uno nuevo válido:
+  Cuando necesitas modificar el valor, no mutas el objeto original. Creas uno nuevo válido:
 </p>
 
 ```ts
@@ -161,11 +161,11 @@ const updated = percentage.update(80)
 <br />
 
 <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem;">
-  <li>Mantenelos <strong>inmutables</strong></li>
-  <li>Validá siempre en el constructor</li>
-  <li>Evitá exponer setters</li>
-  <li>Usá nombres del dominio, no técnicos</li>
-  <li>Hacelos pequeños y específicos</li>
+  <li>Mantenlos <strong>inmutables</strong></li>
+  <li>Valida siempre en el constructor</li>
+  <li>Evita exponer setters</li>
+  <li>Usa nombres del dominio, no técnicos</li>
+  <li>Hazlos pequeños y específicos</li>
 </ul>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
@@ -186,18 +186,18 @@ const updated = percentage.update(80)
 <br />
 
 ```mermaid
-flowchart TD
-    IN[Input primitivo\nstring / number] --> VO
+flowchart TB
+    IN["Input primitivo<br/>string / number"] --> VO
 
     subgraph VO[Value Object]
+        direction TB
         V{Validación}
         V -->|inválido| ERR[DomainError]
         V -->|válido| OBJ[Objeto inmutable]
     end
 
     OBJ --> E[Entidad / Agregado]
-    E -->|usa| OBJ
-    OBJ -->|comparación por valor| OBJ2[Otro Value Object]
+    OBJ -.->|comparación por valor| OBJ2[Otro Value Object]
 
     style VO fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff
     style ERR fill:#3b0764,stroke:#a855f7,color:#f3e8ff
@@ -220,7 +220,7 @@ flowchart TD
 </ul>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
-  Y cuando los adoptás bien… tu diseño cambia por completo.
+  Y cuando los adoptas bien… tu diseño cambia por completo.
 </p>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />

--- a/src/content/blog/08-comunicacion-bounded-contexts-eda.md
+++ b/src/content/blog/08-comunicacion-bounded-contexts-eda.md
@@ -6,7 +6,7 @@ tags: ["Event-Driven Architecture", "DDD", "Bounded Contexts", "RabbitMQ", "Code
 ---
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Seguimos con la serie de <strong>Code Finances</strong> y hoy entramos en un tema clave cuando trabajás con Domain Driven Design: cómo se comunican los distintos Bounded Contexts.
+  Seguimos con la serie de <strong>Code Finances</strong> y hoy entramos en un tema clave cuando trabajas con Domain Driven Design: cómo se comunican los distintos Bounded Contexts.
 </p>
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
@@ -52,29 +52,31 @@ eventBus.publish(new RevenueCreatedEvent(...))
 </p>
 
 ```mermaid
-flowchart LR
+flowchart TB
     subgraph CF[Cash Flow BC]
-        UC[CreateRevenue\nUseCase]
-        UC -->|emite| EV[RevenueCreatedEvent]
+        direction TB
+        UC["CreateRevenue<br/>UseCase"]
+        EV[RevenueCreatedEvent]
+        UC -->|emite| EV
     end
 
     EV -->|publica| RMQ[RabbitMQ]
 
+    RMQ --> S1
+    RMQ --> S2
+    RMQ --> S3
+
     subgraph LC[Liquidity Categories BC]
-        S1[AllocateLiquidity\nSubscriber]
+        S1["AllocateLiquidity<br/>Subscriber"]
     end
 
     subgraph EQ[Equity BC]
-        S2[UpdateEquity\nSubscriber]
+        S2["UpdateEquity<br/>Subscriber"]
     end
 
     subgraph PR[Projections BC]
-        S3[RecalcProjections\nSubscriber]
+        S3["RecalcProjections<br/>Subscriber"]
     end
-
-    RMQ -->|consume| S1
-    RMQ -->|consume| S2
-    RMQ -->|consume| S3
 
     style CF fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff
     style LC fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff
@@ -116,7 +118,7 @@ flowchart LR
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Una de las decisiones más importantes: <strong>cómo nombrás tus eventos</strong>. En <em>Code Finances</em> seguimos estas convenciones:
+  Una de las decisiones más importantes: <strong>cómo nombras tus eventos</strong>. En <em>Code Finances</em> seguimos estas convenciones:
 </p>
 
 <h3 style="color:oklch(67.3% 0.182 276.935); font-weight:600; margin-top:1.5rem;">🔑 Eventos de dominio</h3>

--- a/src/content/blog/09-repository-pattern-dominio-sin-acoplamiento.md
+++ b/src/content/blog/09-repository-pattern-dominio-sin-acoplamiento.md
@@ -38,7 +38,7 @@ tags: ["Repository Pattern", "DDD", "Clean Architecture", "SOLID", "Code Finance
 <br />
 
 <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
-  Es un patrón que nos permite <strong>encapsular la lógica de persistencia</strong> y <strong>desacoplar el dominio de la infraestructura</strong>. Tu dominio <strong>no sabe</strong> si usás SQL, NoSQL o cualquier otra cosa.
+  Es un patrón que nos permite <strong>encapsular la lógica de persistencia</strong> y <strong>desacoplar el dominio de la infraestructura</strong>. Tu dominio <strong>no sabe</strong> si usas SQL, NoSQL o cualquier otra cosa.
 </p>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
@@ -48,8 +48,8 @@ tags: ["Repository Pattern", "DDD", "Clean Architecture", "SOLID", "Code Finance
 
 <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem;">
   <li>✅ <strong>SRP</strong> — cada clase tiene una única responsabilidad</li>
-  <li>🔓 <strong>OCP</strong> — podés extender sin modificar</li>
-  <li>🔌 <strong>DIP</strong> — dependés de interfaces, no de implementaciones</li>
+  <li>🔓 <strong>OCP</strong> — puedes extender sin modificar</li>
+  <li>🔌 <strong>DIP</strong> — dependes de interfaces, no de implementaciones</li>
 </ul>
 
 <hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
@@ -89,29 +89,32 @@ class TypeOrmLiquidityCategoryRepository implements LiquidityCategoryRepository 
 
 ```mermaid
 flowchart TB
-    subgraph Dominio
-        I[LiquidityCategoryRepository\ninterfaz]
+    subgraph Aplicacion[Aplicación]
+        UC["LiquidityCategoryCreator<br/>caso de uso"]
     end
 
-    subgraph Aplicación
-        UC[LiquidityCategoryCreator\ncaso de uso]
-        UC -->|depende de| I
+    subgraph Dominio
+        I["LiquidityCategoryRepository<br/>interfaz"]
     end
+
+    UC -->|depende de| I
 
     subgraph Infraestructura
-        IMPL[TypeOrmLiquidityCategory\nRepository]
-        IMPL -->|implementa| I
-        DB[(PostgreSQL\nTypeORM)]
+        direction TB
+        IMPL["TypeOrmLiquidityCategory<br/>Repository"]
+        DB[("PostgreSQL<br/>TypeORM")]
         IMPL --> DB
     end
 
     subgraph Tests
-        MOCK[InMemoryRepository\nmock]
-        MOCK -->|implementa| I
+        MOCK["InMemoryRepository<br/>mock"]
     end
 
+    I -.->|implementa| IMPL
+    I -.->|implementa| MOCK
+
     style Dominio fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff
-    style Aplicación fill:#0f172a,stroke:#818cf8,color:#e0e7ff
+    style Aplicacion fill:#0f172a,stroke:#818cf8,color:#e0e7ff
     style Infraestructura fill:#0f172a,stroke:#818cf8,color:#e0e7ff
     style Tests fill:#1e3a1e,stroke:#4ade80,color:#dcfce7
 ```
@@ -137,18 +140,18 @@ flowchart TB
   <div style="flex:1; min-width:200px;">
     <p style="color:#f87171; font-weight:600; margin-bottom:0.5rem;">❌ Enfoque típico</p>
     <ol style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.25rem;">
-      <li>Elegís base de datos</li>
-      <li>Diseñás tablas</li>
-      <li>Adaptás el dominio a eso</li>
+      <li>Eliges base de datos</li>
+      <li>Diseñas tablas</li>
+      <li>Adaptas el dominio a eso</li>
     </ol>
     <p style="color:#f87171; margin-top:0.75rem; font-size:0.9rem;">→ Dominio acoplado, difícil de cambiar, código rígido.</p>
   </div>
   <div style="flex:1; min-width:200px;">
     <p style="color:oklch(67.3% 0.182 276.935); font-weight:600; margin-bottom:0.5rem;">✅ Enfoque correcto</p>
     <ol style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.25rem;">
-      <li>Diseñás el dominio</li>
-      <li>Definís repositorios (interfaces)</li>
-      <li>Implementás la infraestructura después</li>
+      <li>Diseñas el dominio</li>
+      <li>Defines repositorios (interfaces)</li>
+      <li>Implementas la infraestructura después</li>
     </ol>
     <p style="color:oklch(67.3% 0.182 276.935); margin-top:0.75rem; font-size:0.9rem;">→ La base de datos es un detalle. El dominio es lo importante.</p>
   </div>

--- a/src/content/blog/10-testeabilidad-vs-observabilidad.md
+++ b/src/content/blog/10-testeabilidad-vs-observabilidad.md
@@ -1,0 +1,263 @@
+---
+title: "Testeabilidad vs observabilidad: no compiten, se complementan"
+description: "La testeabilidad te da feedback antes de producción; la observabilidad te explica qué pasa cuando el sistema ya está vivo. Entender la diferencia cambia cómo diseñas software."
+pubDate: 2026-05-01
+tags:
+  ["Testing", "Observability", "Arquitectura", "Diseño de Software", "Calidad", "Buenas Prácticas"]
+---
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  Hay dos conceptos que mucha gente mezcla como si fueran sinónimos: <strong>testeabilidad</strong> y <strong>observabilidad</strong>.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  Y no, no son lo mismo. Se relacionan, sí. Pero cumplen papeles distintos en la arquitectura de un sistema.
+</p>
+
+<blockquote style="border-left:3px solid oklch(67.3% 0.182 276.935); padding-left:1rem; margin:1.5rem 0; color:#94A3B8; font-style:italic;">
+  La testeabilidad reduce incertidumbre <strong>antes</strong> de producción. La observabilidad reduce incertidumbre <strong>durante</strong> producción.
+</blockquote>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  Si confundes esas dos ideas, terminas diseñando sistemas que parecen sólidos… pero solo hasta que algo falla de verdad.
+</p>
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">🧪 ¿Qué es la testeabilidad?</h2>
+<br />
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  La <strong>testeabilidad</strong> es la facilidad con la que puedes <strong>provocar estados</strong>, <strong>controlar dependencias</strong> y <strong>verificar resultados</strong> en tu software.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  O dicho más directo: qué tan fácil es demostrar, de forma automatizada, que una pieza del sistema se comporta como esperas.
+</p>
+
+<ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:0.75rem;">
+  <li>✅ Dependencias explícitas e inyectables</li>
+  <li>✅ Entradas y salidas claras</li>
+  <li>✅ Poca magia y poco acoplamiento</li>
+  <li>✅ Feedback rápido, repetible y determinista</li>
+</ul>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  Un sistema testeable no es el que “tiene muchos tests”. Es el que <strong>está diseñado para que testear sea natural</strong>.
+</p>
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">📡 ¿Qué es la observabilidad?</h2>
+<br />
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  La <strong>observabilidad</strong> es la capacidad de entender qué está pasando dentro de un sistema <strong>a partir de las señales que emite</strong> mientras corre en entornos reales.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  No se trata solo de tener logs. Se trata de poder responder preguntas como estas sin rezar:
+</p>
+
+<ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:0.75rem;">
+  <li>🔍 ¿Qué request falló?</li>
+  <li>📈 ¿Cuándo empezó a degradarse la latencia?</li>
+  <li>🧵 ¿En qué servicio se rompió la cadena?</li>
+  <li>👤 ¿A qué usuarios afectó?</li>
+</ul>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  Para eso necesitas <strong>logs con contexto</strong>, <strong>métricas útiles</strong>, <strong>trazas</strong> y, sobre todo, señales pensadas desde el diseño.
+</p>
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">❌ El error común: enfrentarlas</h2>
+<br />
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  Aquí viene la confusión típica: pensar que si un sistema es muy observable entonces no hace falta que sea tan testeable. O al revés.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  No. Es como tener <strong>tipado estático</strong> y <strong>logs en producción</strong>. El tipado previene clases enteras de bugs antes de que el código corra; los logs te explican qué hizo el sistema cuando los datos no eran los que esperabas. Nadie discute cuál elegir, porque atacan momentos distintos del ciclo de vida.
+</p>
+
+<div style="display:flex; gap:2rem; flex-wrap:wrap; margin-top:1rem;">
+  <div style="flex:1; min-width:220px;">
+    <p style="color:oklch(67.3% 0.182 276.935); font-weight:600; margin-bottom:0.5rem;">Testeabilidad</p>
+    <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.25rem;">
+      <li>Actúa antes del despliegue</li>
+      <li>Reduce el coste de cambio</li>
+      <li>Ayuda a diseñar mejor</li>
+      <li>Valida comportamiento esperado</li>
+    </ul>
+  </div>
+  <div style="flex:1; min-width:220px;">
+    <p style="color:oklch(67.3% 0.182 276.935); font-weight:600; margin-bottom:0.5rem;">Observabilidad</p>
+    <ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.25rem;">
+      <li>Actúa con el sistema en marcha</li>
+      <li>Reduce el coste de diagnóstico</li>
+      <li>Ayuda a operar mejor</li>
+      <li>Explica comportamiento real</li>
+    </ul>
+  </div>
+</div>
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">🧠 La diferencia, dibujada</h2>
+<br />
+
+```mermaid
+flowchart TB
+    A[Diseño del sistema]
+    A --> B{¿Qué incertidumbre<br/>quieres reducir?}
+
+    B -->|Antes de<br/>producción| T[Testeabilidad]
+    B -->|Durante<br/>producción| O[Observabilidad]
+
+    T --> T1[Dependencias explícitas]
+    T1 --> T2[Entradas y salidas controlables]
+    T2 --> T3[Tests rápidos y deterministas]
+    T3 --> T4[Feedback barato antes de desplegar]
+
+    O --> O1[Logs con contexto]
+    O1 --> O2[Métricas]
+    O2 --> O3[Tracing]
+    O3 --> O4[Feedback real en ejecución]
+
+    T4 --> C[Confianza para cambiar]
+    O4 --> C
+    C --> D[Menos tiempo persiguiendo errores]
+
+    style A fill:#0f172a,stroke:#818cf8,color:#e0e7ff
+    style B fill:#1e1b4b,stroke:#818cf8,color:#e0e7ff
+    style T fill:#1e3a1e,stroke:#4ade80,color:#dcfce7
+    style O fill:#082f49,stroke:#38bdf8,color:#e0f2fe
+    style C fill:#3b0764,stroke:#a855f7,color:#f3e8ff
+    style D fill:#0f172a,stroke:#818cf8,color:#e0e7ff
+```
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">⚖️ Casos reales: qué pasa cuando te falta una</h2>
+<br />
+
+<div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(230px, 1fr)); gap:1rem; margin-top:1rem;">
+  <div style="border:1px solid #334155; border-radius:0.75rem; padding:1rem; background:rgba(15,23,42,.45);">
+    <p style="color:#4ade80; font-weight:700; margin-bottom:0.5rem;">Alta testeabilidad + baja observabilidad</p>
+    <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+      Tu pipeline está en verde, pero en producción no entiendes por qué falla un flujo. Cambias con seguridad, pero operas a ciegas.
+    </p>
+  </div>
+
+  <div style="border:1px solid #334155; border-radius:0.75rem; padding:1rem; background:rgba(15,23,42,.45);">
+    <p style="color:#38bdf8; font-weight:700; margin-bottom:0.5rem;">Baja testeabilidad + alta observabilidad</p>
+    <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+      Ves perfectamente el incendio en producción, pero cada fix es caro y arriesgado porque el sistema está acoplado y cuesta aislarlo.
+    </p>
+  </div>
+
+  <div style="border:1px solid #334155; border-radius:0.75rem; padding:1rem; background:rgba(15,23,42,.45);">
+    <p style="color:#f87171; font-weight:700; margin-bottom:0.5rem;">Baja testeabilidad + baja observabilidad</p>
+    <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+      Caos total: no previenes errores antes ni los entiendes después. Cada cambio se siente como apostar a ciegas.
+    </p>
+  </div>
+
+  <div style="border:1px solid #334155; border-radius:0.75rem; padding:1rem; background:rgba(15,23,42,.45);">
+    <p style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-bottom:0.5rem;">Alta testeabilidad + alta observabilidad</p>
+    <p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+      Este es el punto sano: cambias con confianza y, si algo ocurre en producción, tienes señales para entenderlo rápido.
+    </p>
+  </div>
+</div>
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">🛠️ Una decisión, dos beneficios</h2>
+<br />
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  En lugar de listar buenas prácticas genéricas, mejor un caso concreto. Imaginemos un caso de uso del estilo de los que tengo en <strong>Code Finances</strong>: registrar un ingreso de un usuario.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  La decisión de diseño es simple: el caso de uso recibe sus dependencias por constructor (puerto del repositorio + publicador de eventos) y, al completar la operación, emite un <code>RevenueRegistered</code>.
+</p>
+
+```ts
+class RevenueRegistrar {
+  constructor(
+    private readonly repository: RevenueRepository,
+    private readonly publisher: DomainEventsPublisher,
+  ) {}
+
+  async execute(request: RequestRevenueRegistrar): Promise<void> {
+    const revenue = Revenue.create(input);
+
+    await this.repository.save(revenue);
+
+    await this.publisher.publish(revenue.pullDomainEvents());
+  }
+}
+```
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1.25rem;">
+  Esa misma decisión te paga en los dos frentes:
+</p>
+
+<ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:0.5rem;">
+  <li>🧪 <strong>Testeabilidad</strong>: en el test mockeo <code>RevenueRepository</code> y <code>EventPublisher</code>, ejecuto el caso de uso y verifico dos cosas: que se persistió el ingreso y que se publicó el evento. Sin frameworks de por medio, sin base de datos, sin red.</li>
+  <li>🔭 <strong>Observabilidad</strong>: el handler de <code>RevenueRegistered</code> es donde vive el log estructurado con <code>correlation_id</code>, <code>user_id</code> y <code>amount</code>; ahí también incremento la métrica <code>revenues_registered_total</code>. La traza nace del evento de dominio, no contamina el caso de uso.</li>
+</ul>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1.25rem;">
+  Ese es el patrón a perseguir: <strong>una sola decisión de diseño que mejora ambas cualidades a la vez</strong>. De ahí salen tres principios que conviene tener siempre en la cabeza:
+</p>
+
+<ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:0.5rem;">
+  <li>🔌 <strong>Dependencias explícitas</strong> — lo que entra por el constructor se mockea en tests y se instrumenta en producción.</li>
+  <li>📣 <strong>Eventos de dominio como punto de instrumentación</strong> — el caso de uso se mantiene puro; logs y métricas viven en los handlers.</li>
+  <li>🧭 <strong>Lenguaje del dominio</strong> — si el evento se llama <code>RevenueRegistered</code>, el test, el log y el dashboard hablan el mismo idioma.</li>
+</ul>
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">💸 Los trade-offs reales</h2>
+<br />
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  Ojo: ninguna de las dos es gratis.
+</p>
+
+<ul style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-left:1.5rem; margin-top:0.75rem;">
+  <li>La <strong>testeabilidad</strong> exige diseño, disciplina y evitar atajos acoplados.</li>
+  <li>La <strong>observabilidad</strong> implica coste operativo, volumen de datos y la tentación de llenar todo de ruido inútil.</li>
+</ul>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  Por eso la conversación madura no es “¿cuál elijo?”. La conversación madura es: <strong>¿qué nivel de testeabilidad y observabilidad necesita este sistema según su criticidad y coste de fallo?</strong>
+</p>
+
+<hr style="margin:2rem 0; border:none; border-top:1px solid #CBD5E1;" />
+
+<h2 style="color:oklch(67.3% 0.182 276.935); font-weight:700; margin-top:2rem;">💬 Conclusión</h2>
+<br />
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894);">
+  La testeabilidad y la observabilidad no son rivales. Son <strong>dos mecanismos distintos para bajar incertidumbre</strong> en momentos diferentes de la vida del software.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  Si tu sistema solo es testeable, sufrirás cuando llegue a producción. Si tu sistema solo es observable, sufrirás cada vez que necesites cambiarlo.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  El punto serio de ingeniería está en construir software que pueda <strong>probarse bien</strong> y también <strong>explicarse bien</strong> cuando ya está corriendo.
+</p>
+
+<p style="line-height:1.7; color:oklch(86.9% 0.022 252.894); margin-top:1rem;">
+  Porque la calidad no aparece por magia. Se diseña.
+</p>


### PR DESCRIPTION
## Summary

- Nuevo post (#10): _Testeabilidad vs Observabilidad_ — qué miden, cuándo aplicar cada una, y cómo una decisión de diseño (DI + eventos de dominio) compra ambas simultáneamente.
- Sección \"Cómo diseñar para las dos\" reescrita con caso de uso `RegisterRevenue` estilo Code Finances + 3 principios derivados del ejemplo (en vez de un checklist genérico).
- Analogía \"obra/planos\" reemplazada por \"tipado estático + logs en producción\".
- Todos los diagramas Mermaid del blog rediseñados a orientación vertical (`flowchart TB`) para escalar mejor en columna de blog.
- Font-size dinámico en Mermaid: JS calcula `--mermaid-font` compensando la escala del viewBox para que el texto se vea siempre al mismo tamaño real (~16px) independientemente del tamaño del diagrama.
- Fix: diagramas ya no se desbordan del article ni pisan contenido del layout.

## Changes

| File | Change |
|------|--------|
| `src/content/blog/10-testeabilidad-vs-observabilidad.md` | Nuevo post + reescritura de sección + analogía |
| `src/layouts/BlogLayout.astro` | Font-size dinámico + CSS Mermaid refactorizado |
| `src/content/blog/03-postgresql-como-cola-de-mensajeria.md` | Diagrama → `TB` |
| `src/content/blog/05-criteria-filtros-dinamicos-paginacion-ddd.md` | Diagrama `LR` → `TB` |
| `src/content/blog/07-value-objects-guardianes-del-dominio.md` | Diagrama → `TB` |
| `src/content/blog/08-comunicacion-bounded-contexts-eda.md` | Diagrama `LR` → `TB` |
| `src/content/blog/09-repository-pattern-dominio-sin-acoplamiento.md` | Diagrama reorganizado en `TB` |

## Test Plan

- [x] Revisión visual en local de todos los posts con diagramas
- [x] Verificado castellano de España sin regionalismos (grep limpio)